### PR TITLE
Hotfix/industry fragment

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/filterindustry/ui/IndustryAdapter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filterindustry/ui/IndustryAdapter.kt
@@ -36,7 +36,7 @@ class IndustryAdapter(
     }
 
     override fun onBindViewHolder(holder: IndustryViewHolder, position: Int) {
-        val industry = items[position]
+        val industry = filteredItems[position]
         val isSelected = industry.id.toString() == selectedIndustryId
         holder.bind(industry, isSelected)
     }

--- a/app/src/main/java/ru/practicum/android/diploma/filterindustry/ui/IndustryFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filterindustry/ui/IndustryFragment.kt
@@ -54,7 +54,7 @@ class IndustryFragment : Fragment() {
 
         lifecycleScope.launch {
             val params = filteringUseCase.loadParameters()
-            val selectedIndustryId = params?.industry ?: "" // industry хранится как String ID
+            val selectedIndustryId = params?.industryId?.toString() ?: "" // industry хранится как String ID
 
             viewModel.getIndustries(selectedIndustryId) // передаем ID для выделения
         }
@@ -62,9 +62,8 @@ class IndustryFragment : Fragment() {
         viewModel.industryState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is IndustryState.Content -> {
-                    adapter.updateItems(state.industryList, selectedId = null)
+                    adapter.updateItems(state.industryList, state.selectedIndustryId)
                     updateApplyButtonVisibility()
-                    adapter.updateItems(state.industryList, args.selectedIndustryId)
                     binding.industryScrolls.visibility = View.VISIBLE
                     binding.placeholderImage.visibility = View.GONE
                     binding.placeholderText.visibility = View.GONE
@@ -78,7 +77,6 @@ class IndustryFragment : Fragment() {
                 }
             }
         }
-        viewModel.getIndustries()
         binding.industryEditText.addTextChangedListener { editable ->
             val hasText = !editable.isNullOrEmpty()
             val iconRes = if (hasText) R.drawable.ic_clear_button else R.drawable.ic_search
@@ -102,7 +100,8 @@ class IndustryFragment : Fragment() {
 
                 // Создаем обновленные параметры
                 val updatedParams = (currentParams ?: FilterParameters()).copy(
-                    industry = selectedIndustry?.id.toString()
+                    industry = selectedIndustry?.name.toString(),
+                    industryId = selectedIndustry?.id ?: 0
                 )
 
                 // Сохраняем


### PR DESCRIPTION
Исправил проблему, из за которой в поле отраслей экрана фильтры передавался id отрасли
Исправил проблему отображения уже выбранной отрасли в списке отраслей
Исправил некорректную фильтрацию списка отраслей по поисковому запросу (на экране выбора отраслей)