### PR TITLE
hotfix/FilteringViewModel

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/filtersettings/ui/FilteringViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filtersettings/ui/FilteringViewModel.kt
@@ -52,7 +52,10 @@ class FilteringViewModel(
         viewModelScope.launch {
             val currentParams = filteringUseCase.loadParameters() ?: FilterParameters()
             val updatedParams = currentParams.copy(
-                country = "", countryId = 0, region = "", regionId = 0
+                country = "",
+                countryId = 0,
+                region = "",
+                regionId = 0
             )
             filteringUseCase.saveParameters(updatedParams)
 
@@ -66,9 +69,7 @@ class FilteringViewModel(
     fun clearIndustry() {
         viewModelScope.launch {
             val currentParams = filteringUseCase.loadParameters() ?: FilterParameters()
-            val updatedParams = currentParams.copy(
-                industry = "", industryId = 0
-            )
+            val updatedParams = currentParams.copy(industry = "", industryId = 0)
             filteringUseCase.saveParameters(updatedParams)
 
             val currentState = _filterState.value ?: FilterState()


### PR DESCRIPTION
- Исправил логику FilteringViewModel в части сохранения и обновления на экране параметров фильтров. Проблема была в том, что если поле отрасли не пустое, то установка чек бокса "только с зарплатой" или установка желайемой зарплаты обнуляли поле industryId.
- Изменена логика отчистки полей "место работы" и "отрасли"